### PR TITLE
Fix date input initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
             <div class="transaction-form">
                 <div class="form-group">
                     <label>Date</label>
-                    <input type="date" id="transDate" value="${new Date().toISOString().split('T')[0]}">
+                    <input type="date" id="transDate">
                 </div>
                 <div class="form-group">
                     <label>Description</label>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,10 @@
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 const tooltip = document.getElementById('tooltip');
+const transDateInput = document.getElementById('transDate');
+if (transDateInput) {
+    transDateInput.value = new Date().toISOString().split('T')[0];
+}
 
 let width, height;
 let particles = [];


### PR DESCRIPTION
## Summary
- remove unused template literal for transaction date in HTML
- initialize date input value in JavaScript on load

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6843ed9053608322b3d217f15de54333