### PR TITLE
Fix draw loop to persist across views

### DIFF
--- a/script.js
+++ b/script.js
@@ -694,7 +694,6 @@ function draw(){
     if(currentView==='transactions'){
         ctx.fillStyle='#0a0a0a';
         ctx.fillRect(0,0,width,height);
-        return;
     } else if(currentView==='flow'){
         drawFlowView();
     } else if(currentView==='budget'){


### PR DESCRIPTION
## Summary
- ensure the draw loop keeps running when viewing Transactions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843f585a8e48322bef74a84585942c9